### PR TITLE
Add FutureSignal that wraps futures

### DIFF
--- a/packages/preact_signals/lib/preact_signals.dart
+++ b/packages/preact_signals/lib/preact_signals.dart
@@ -12,3 +12,4 @@ export 'src/signals.dart'
         ReadonlySignal;
 export 'src/extensions.dart';
 export 'src/signal_state.dart';
+export 'src/future_signal.dart';

--- a/packages/preact_signals/lib/src/extensions/future.dart
+++ b/packages/preact_signals/lib/src/extensions/future.dart
@@ -1,6 +1,6 @@
 import 'package:preact_signals/preact_signals.dart';
 
-/// Returns a [ReadonlySignal] that uses [SignalState] for the value.
+/// A [Signal] that wraps a [Future]
 ///
 /// Starts with [SignalLoading] for the default
 /// state until the future completes.
@@ -8,44 +8,35 @@ import 'package:preact_signals/preact_signals.dart';
 /// When an error occurs [SignalError] is returned with the value
 /// being the [Object] of the exception
 ///
-/// If a [Duration] is added for the timeout and the
-/// timeout is reached [SignalTimeout] will return and
-/// extends [SignalError]
-///
 /// If success then the result will be [SignalValue]
-ReadonlySignal<SignalState> signalFromFuture<T>(
-  Future<T> future, {
-  Duration? timeout,
-}) {
-  final s = signal<SignalState>(SignalLoading());
-  bool started = false;
-
-  Future<SignalState> execute() async {
-    var f = future.then<SignalState>((val) {
-      return SignalValue(val);
-    }).catchError((err) {
-      return SignalError(err);
-    });
-    if (timeout != null) {
-      f = f.timeout(timeout, onTimeout: () {
-        return SignalTimeout();
-      });
-    }
-    return await f;
+class FutureSignal<T> extends Signal<SignalState> {
+  /// Creates a [FutureSignal] that wraps a [Future]
+  FutureSignal(this._getFuture) : super(SignalLoading()) {
+    _init();
   }
 
-  s.subscribe((value) {
-    if (!started) {
-      started = true;
-      execute().then((value) => s.value = value);
-    }
-  });
+  final Future<T> Function() _getFuture;
 
-  return s;
+  /// Resets the signal by calling the [Future] again
+  void reset() {
+    _init();
+  }
+
+  void _init() {
+    if (peek() is! SignalLoading) {
+      value = SignalLoading();
+    }
+
+    _getFuture().then((value) {
+      this.value = SignalValue(value);
+    }).catchError((error) {
+      value = SignalError(error);
+    });
+  }
 }
 
 /// Extension on future to provide helpful methods for signals
 extension SignalFutureUtils on Future {
   /// Convert an existing future to [ReadonlySignal]
-  ReadonlySignal toSignal() => signalFromFuture(this);
+  toSignal() => FutureSignal(() => this);
 }

--- a/packages/preact_signals/lib/src/extensions/future.dart
+++ b/packages/preact_signals/lib/src/extensions/future.dart
@@ -1,42 +1,7 @@
-import 'package:preact_signals/preact_signals.dart';
-
-/// A [Signal] that wraps a [Future]
-///
-/// Starts with [SignalLoading] for the default
-/// state until the future completes.
-///
-/// When an error occurs [SignalError] is returned with the value
-/// being the [Object] of the exception
-///
-/// If success then the result will be [SignalValue]
-class FutureSignal<T> extends Signal<SignalState> {
-  /// Creates a [FutureSignal] that wraps a [Future]
-  FutureSignal(this._getFuture) : super(SignalLoading()) {
-    _init();
-  }
-
-  final Future<T> Function() _getFuture;
-
-  /// Resets the signal by calling the [Future] again
-  void reset() {
-    _init();
-  }
-
-  void _init() {
-    if (peek() is! SignalLoading) {
-      value = SignalLoading();
-    }
-
-    _getFuture().then((value) {
-      this.value = SignalValue(value);
-    }).catchError((error) {
-      value = SignalError(error);
-    });
-  }
-}
+import 'package:preact_signals/src/future_signal.dart';
 
 /// Extension on future to provide helpful methods for signals
 extension SignalFutureUtils on Future {
-  /// Convert an existing future to [ReadonlySignal]
+  /// Convert an existing future to [FutureSignal]
   toSignal() => FutureSignal(() => this);
 }

--- a/packages/preact_signals/lib/src/future_signal.dart
+++ b/packages/preact_signals/lib/src/future_signal.dart
@@ -1,0 +1,36 @@
+import 'package:preact_signals/preact_signals.dart';
+
+/// A [Signal] that wraps a [Future]
+///
+/// Starts with [SignalLoading] for the default
+/// state until the future completes.
+///
+/// When an error occurs [SignalError] is returned with the value
+/// being the [Object] of the exception
+///
+/// If success then the result will be [SignalValue]
+class FutureSignal<T> extends Signal<SignalState> {
+  /// Creates a [FutureSignal] that wraps a [Future]
+  FutureSignal(this._getFuture) : super(SignalLoading()) {
+    _init();
+  }
+
+  final Future<T> Function() _getFuture;
+
+  /// Resets the signal by calling the [Future] again
+  void reset() {
+    _init();
+  }
+
+  void _init() {
+    if (peek() is! SignalLoading) {
+      value = SignalLoading();
+    }
+
+    _getFuture().then((value) {
+      this.value = SignalValue(value);
+    }).catchError((error) {
+      value = SignalError(error);
+    });
+  }
+}

--- a/packages/preact_signals/test/future_test.dart
+++ b/packages/preact_signals/test/future_test.dart
@@ -7,7 +7,7 @@ void main() {
   group('Future', () {
     test('signalFromFuture', () async {
       final future = _future();
-      final signal = signalFromFuture(future);
+      final signal = FutureSignal(() => future);
       expect(signal() is SignalLoading, true);
 
       final completer = Completer<int>();

--- a/packages/preact_signals/test/future_test.dart
+++ b/packages/preact_signals/test/future_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:preact_signals/preact_signals.dart';
+import 'package:preact_signals/src/future_signal.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
Re: #6 

This class makes it straightforward to reset the state of the signal.

#### Usage:

```dart
fetchData() {
  return 'abc';
}

final futureSignal = FutureSignal<String>(
  () => Future.delayed(const Duration(seconds: 1), () => fetchData()),
);

class MyHomePage extends StatelessWidget {
  const MyHomePage({super.key, required this.title});

  final String title;

  void _reloadData() {
    futureSignal.reset();
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text(title),
      ),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            Builder(builder: (context) {
              final state = futureSignal.watch(context);
              final text = switch (state) {
                SignalError(value: var v) => 'Error: $v',
                SignalValue(value: var v) => 'Success: $v',
                _ => 'Loading...',
              };
              return Text(
                text,
                style: Theme.of(context).textTheme.headlineMedium!,
              );
            }),
          ],
        ),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: _reloadData,
        child: const Icon(Icons.refresh),
      ),
    );
  }
}

```