### PR TITLE
Conserve generic from future and stream to Signal

### DIFF
--- a/packages/preact_signals/lib/src/extensions/future.dart
+++ b/packages/preact_signals/lib/src/extensions/future.dart
@@ -1,10 +1,10 @@
 import 'package:preact_signals/src/future_signal.dart';
 
 /// Extension on future to provide helpful methods for signals
-extension SignalFutureUtils on Future {
+extension SignalFutureUtils<T> on Future<T> {
   /// Convert an existing future to [FutureSignal]
-  FutureSignal toSignal({Duration? timeout}) {
-    return FutureSignal(
+  FutureSignal<T> toSignal({Duration? timeout}) {
+    return FutureSignal<T>(
       () => this,
       timeout: timeout,
     );

--- a/packages/preact_signals/lib/src/extensions/stream.dart
+++ b/packages/preact_signals/lib/src/extensions/stream.dart
@@ -3,10 +3,10 @@ import 'package:preact_signals/preact_signals.dart';
 import '../stream_signal.dart';
 
 /// Extension on stream to provide helpful methods for signals
-extension SignalStreamUtils on Stream {
+extension SignalStreamUtils<T> on Stream<T> {
   /// Return [ReadonlySignal] from an existing stream
-  StreamSignal toSignal({bool? cancelOnError}) {
-    return StreamSignal(
+  StreamSignal<T> toSignal({bool? cancelOnError}) {
+    return StreamSignal<T>(
       () => this,
       cancelOnError: cancelOnError,
     );


### PR DESCRIPTION
Just transmit Generic of T when calling Stream.fromSignal() and Future.

Signal now hold the generic yet we still need to be explicit as inference 
it not aware because SignalState has no generic.

Open question #12 


```dart
source.subscribe((v) {
    // now a int but still generic without explicit cast
    if (v is SignalValue<int>) print(v.value); 
});
```

  ```dart
final v = source.value;

    switch (v) {
      case SignalValue():
        print('===> ${v.value}' ); // value is generic 
      case SignalError():
        print('error');
      case SignalLoading():
        print("loading");
    }

```

